### PR TITLE
Fix bug in residual_block

### DIFF
--- a/model.py
+++ b/model.py
@@ -23,7 +23,7 @@ def residual_block(x, num_filters):
     x = BatchNormalization()(x)
 
     s = Conv2D(num_filters, (1, 1), padding="same")(x_init)
-    s = BatchNormalization()(x)
+    s = BatchNormalization()(s)
 
     x = Add()([x, s])
     x = Activation("relu")(x)


### PR DESCRIPTION
Hello sir,

In your [paper](https://github.com/DebeshJha/NanoNet/blob/main/nanonet-jha.pdf), it is reported that the NanoNet-C has parameters of `36K`. Yet, when I try to replicate the model in PyTorch, available online on [my repository](https://github.com/reshalfahsi/NanoNet-PyTorch), the number of parameters doesn't match up. Instead, it has `43K` parameters. After carefully reading your code, I found an error in the [`residual_block`](https://github.com/DebeshJha/NanoNet/blob/main/model.py#L26) function. However, I have fixed the error summarized in this pull request. Thank you.